### PR TITLE
sdc: add basic metric fetching support

### DIFF
--- a/internal/sdc/cli/cli.go
+++ b/internal/sdc/cli/cli.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sevein/k8s-sysdig-adapter/internal/sdc"
+)
+
+var (
+	client  *sdc.Client
+	rootCmd = &cobra.Command{Use: "sdc-cli"}
+	ctx     = context.Background()
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func run() error {
+	var token = os.Getenv("SDC_TOKEN")
+	if token == "" {
+		return errors.New("token not provided, use environment SDC_TOKEN")
+	}
+	client = sdc.NewClient(nil, token)
+
+	rootCmd.AddCommand(newGetDataCmd(os.Stdout))
+	rootCmd.AddCommand(newListMetricsCmd(os.Stdout))
+	return rootCmd.Execute()
+}
+
+func newGetDataCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "get-data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGetData(out, cmd)
+		},
+	}
+	cmd.Flags().String("metric", "", "Name of the metric")
+	return cmd
+}
+
+func runGetData(out io.Writer, cmd *cobra.Command) error {
+	metric, _ := cmd.Flags().GetString("metric")
+	if metric == "" {
+		return errors.New("metric name is empty")
+	}
+	req := &sdc.GetDataRequest{
+		DataSourceType: "host",
+		Last:           600,
+		Sampling:       60,
+		Metrics: []sdc.Metric{
+			sdc.Metric{
+				ID:           metric,
+				Aggregations: sdc.MetricAggregation{Time: "timeAvg", Group: "avg"},
+			},
+		},
+	}
+	data, _, err := client.Data.Get(ctx, req)
+	if err != nil {
+		return err
+	}
+	for _, item := range data.Data {
+		fmt.Fprintf(out, "Data point: %f (%s)\n", item.Points, item.Time.String())
+	}
+	return nil
+}
+
+func newListMetricsCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "list-metrics",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runListMetrics(out, cmd)
+		},
+	}
+	return cmd
+}
+
+func runListMetrics(out io.Writer, cmd *cobra.Command) error {
+	metrics, _, err := client.Data.Metrics(ctx)
+	if err != nil {
+		return err
+	}
+	for id, metric := range *metrics {
+		fmt.Fprintf(out, "Metric name: %s, type: %s\n", id, metric.Type)
+	}
+	return nil
+}

--- a/internal/sdc/sdc.go
+++ b/internal/sdc/sdc.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://app.sysdigcloud.com/api"
+	defaultBaseURL = "https://app.sysdigcloud.com/api/"
 	userAgent      = "sdc Go library"
 	mediaType      = "application/json"
 )
@@ -27,6 +27,9 @@ type Client struct {
 
 	// User agent for client.
 	UserAgent string
+
+	// Security API token.
+	Token string
 
 	// Services used for communicating with the API.
 	Data DataService
@@ -51,14 +54,14 @@ type ErrorResponse struct {
 }
 
 // NewClient returns a new Sysdig Monitor API client.
-func NewClient(httpClient *http.Client) *Client {
+func NewClient(httpClient *http.Client, token string) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 
 	baseURL, _ := url.Parse(defaultBaseURL)
 
-	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
+	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent, Token: token}
 	c.Data = &DataServiceOp{client: c}
 
 	return c
@@ -68,8 +71,8 @@ func NewClient(httpClient *http.Client) *Client {
 type ClientOpt func(*Client) error
 
 // New returns a new Sysdig Cloud API client instance.
-func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
-	c := NewClient(httpClient)
+func New(httpClient *http.Client, token string, opts ...ClientOpt) (*Client, error) {
+	c := NewClient(httpClient, token)
 	for _, opt := range opts {
 		if err := opt(c); err != nil {
 			return nil, err
@@ -128,6 +131,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body int
 	req.Header.Add("Content-Type", mediaType)
 	req.Header.Add("Accept", mediaType)
 	req.Header.Add("User-Agent", c.UserAgent)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token))
 	return req, nil
 }
 

--- a/internal/sdc/timestamp.go
+++ b/internal/sdc/timestamp.go
@@ -1,0 +1,28 @@
+package sdc
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type Timestamp time.Time
+
+func (t *Timestamp) MarshalJSON() ([]byte, error) {
+	ts := time.Time(*t).Unix()
+	stamp := fmt.Sprint(ts)
+	return []byte(stamp), nil
+}
+
+func (t *Timestamp) UnmarshalJSON(b []byte) error {
+	ts, err := strconv.Atoi(string(b))
+	if err != nil {
+		return err
+	}
+	*t = Timestamp(time.Unix(int64(ts), 0))
+	return nil
+}
+
+func (t *Timestamp) String() string {
+	return time.Time(*t).String()
+}


### PR DESCRIPTION
It's rough but it works!

There is also a simple CLI for testing purposes, e.g:

    $ env SDC_TOKEN=<your-token> go run internal/sdc/cli/cli.go list-metrics
    Metric name: proc.name.client, type: string
    Metric name: swap.limit.used.percent, type: %
    Metric name: container.id, type: string
    ...

    $ env SDC_TOKEN=<your-token> go run internal/sdc/cli/cli.go get-data --metric=cpu.used.percent
    Data point: [2.999000] (2018-04-12 17:00:00 -0700 PDT)
    Data point: [2.965000] (2018-04-12 17:01:00 -0700 PDT)
    ...